### PR TITLE
PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "laravel/pint": "^1.18",
         "pestphp/pest": "^2.36|^3.5",
         "pestphp/pest-plugin-type-coverage": "^2.8|^3.1",
-        "phpstan/phpstan": "^1.12",
-        "phpstan/phpstan-deprecation-rules": "^1.2"
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "laravel/pint": "^1.18",
         "pestphp/pest": "^2.36|^3.5",
         "pestphp/pest-plugin-type-coverage": "^2.8|^3.1",
-        "phpstan/phpstan": "^1.12"
+        "phpstan/phpstan": "^1.12",
+        "phpstan/phpstan-deprecation-rules": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "laravel/pint": "^1.18",
         "pestphp/pest": "^2.36|^3.5",
         "pestphp/pest-plugin-type-coverage": "^2.8|^3.1",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0"
+        "phpstan/phpstan": "^1.10|^2.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 includes:
 	- phpstan-baseline.neon
+	- phar://phpstan.phar/conf/bleedingEdge.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
 	level: 9

--- a/src/Dto/ValidationResult.php
+++ b/src/Dto/ValidationResult.php
@@ -49,7 +49,9 @@ final class ValidationResult
 
     public function getFirstErrorKey(): ?string
     {
-        return (string) array_key_first($this->errors ?? []);
+        return (empty($this->errors))
+            ? null
+            : (string) array_key_first($this->errors);
     }
 
     /**

--- a/tests/TimeDependantTest.php
+++ b/tests/TimeDependantTest.php
@@ -3,10 +3,6 @@
 use Rechtlogisch\WirtschaftsId\WirtschaftsId;
 
 it('returns a hint for unterscheidungsmerkmal different than 00001 before year 2026', function (string $wirtschaftsId) {
-    if (date('Y') >= 2026) {
-        $this->markTestSkipped('This test is only relevant before year 2026.');
-    }
-
     $result = (new WirtschaftsId($wirtschaftsId))->validate();
 
     expect($result->isValid())->toBeTrue()
@@ -17,4 +13,4 @@ it('returns a hint for unterscheidungsmerkmal different than 00001 before year 2
 })->with([
     'DE123456788-00002',
     'DE123456788-99999',
-]);
+])->skip(date('Y') >= 2026, 'This test is only relevant before year 2026.');

--- a/tests/ValidationResultTest.php
+++ b/tests/ValidationResultTest.php
@@ -5,8 +5,10 @@ use Rechtlogisch\WirtschaftsId\Dto\ValidationResult;
 it('returns null as first error when no errors set', function () {
     $dto = new ValidationResult;
     $firstError = $dto->getFirstError();
+    $firstErrorKey = $dto->getFirstErrorKey();
 
-    expect($firstError)->toBeNull();
+    expect($firstError)->toBeNull()
+        ->and($firstErrorKey)->toBeNull();
 });
 
 it('gets contains unterscheidungsmerkmal', function () {


### PR DESCRIPTION
This pull request includes updates to dependencies, configuration files, and a small refactor in the `ValidationResult` class. The most important changes are:

### Dependency Updates:
* Added `phpstan/phpstan-deprecation-rules` to the `composer.json` file.

### Configuration Updates:
* Included `bleedingEdge.neon` and `rules.neon` from `phpstan-deprecation-rules` in the `phpstan.neon` configuration file.

### Code Refactor:
* Refactored `getFirstErrorKey` method in `src/Dto/ValidationResult.php` to return `null` when there are no errors.

### Test Updates:
* Updated `ValidationResultTest.php` to test the new behavior of `getFirstErrorKey`.

🚧 Blocked by [outdated constructor in pest-plugin-type-coverage](https://github.com/pestphp/pest-plugin-type-coverage/pull/35) as of December 27th, 2024.