### PR TITLE
feat: add new ids shared within ERiC Datenabholung test data

### DIFF
--- a/tests/Datasets/Invalid.php
+++ b/tests/Datasets/Invalid.php
@@ -20,6 +20,9 @@ dataset('invalid', [
     'DE777777777',
     'DE888888888',
     'DE999999999',
+    // Following have been shared within retrievable testdata with ERiC Datenabholung for Bereitstellungsdatenart WIdNrVA
+    'DE103810001',
+    'DE103810003',
 ]);
 
 dataset('invalid-with-unterscheidungsmerkmal', [

--- a/tests/Datasets/Valid.php
+++ b/tests/Datasets/Valid.php
@@ -23,6 +23,8 @@ dataset('valid', [
     'DE237998736',
     'DE220178622',
     'DE191592010',
+    // Following have been shared within retrievable testdata with ERiC Datenabholung for Bereitstellungsdatenart WIdNrVA
+    'DE103810007',
 ]);
 
 dataset('valid-with-unterscheidungsmerkmal', [


### PR DESCRIPTION
New test ids:

- DE103810001 (invalid)
- DE103810003 (invalid)
- DE103810007 (valid)