### PR TITLE
chore: Unterscheidungsmerkmal starts in 4th quarter 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This package supports both validation of the Wirtschafts-ID with and without the
 > Unterscheidungsmerkmal starts at `00001` and therefore `00000` is not valid. 
 
 > [!TIP]
-> At first all entities will receive a Wirtschafts-ID with the Unterscheidungsmerkmal `-00001`. If needed, as of 4th Quarter of 2027 each economic activity (wirtschaftliche Tätigkeit) will receive a separate Unterscheidungsmerkmal, which will be incremented by one for each economic activity and linked to a tax number of the business or the permanent establishment within the responsible tax office (cf. [bzst.de](https://www.bzst.de/DE/Unternehmen/Identifikationsnummern/Wirtschafts-Identifikationsnummer/wirtschaftsidentifikationsnummer_node.html#js-toc-entry4)).
+> At first all entities will receive a Wirtschafts-ID with the Unterscheidungsmerkmal `-00001`. If needed, as of 4th quarter of 2027 each economic activity (wirtschaftliche Tätigkeit) will receive a separate Unterscheidungsmerkmal, which will be incremented by one for each economic activity and linked to a tax number of the business or the permanent establishment within the responsible tax office (cf. [bzst.de](https://www.bzst.de/DE/Unternehmen/Identifikationsnummern/Wirtschafts-Identifikationsnummer/wirtschaftsidentifikationsnummer_node.html#js-toc-entry4)).
 > 
 > Source: [BZSt](https://www.bzst.de/DE/Unternehmen/Identifikationsnummern/Wirtschafts-Identifikationsnummer/wirtschaftsidentifikationsnummer_node.html#js-toc-entry4)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This package supports both validation of the Wirtschafts-ID with and without the
 > Unterscheidungsmerkmal starts at `00001` and therefore `00000` is not valid. 
 
 > [!TIP]
-> At first all entities will receive a Wirtschafts-ID with the Unterscheidungsmerkmal `-00001`. If needed, as of 2026 each economic activity (wirtschaftliche Tätigkeit) will receive a separate Unterscheidungsmerkmal, which will be incremented by one for each economic activity and linked to a tax number of the business or the permanent establishment within the responsible tax office.
+> At first all entities will receive a Wirtschafts-ID with the Unterscheidungsmerkmal `-00001`. If needed, as of 4th Quarter of 2027 each economic activity (wirtschaftliche Tätigkeit) will receive a separate Unterscheidungsmerkmal, which will be incremented by one for each economic activity and linked to a tax number of the business or the permanent establishment within the responsible tax office (cf. [bzst.de](https://www.bzst.de/DE/Unternehmen/Identifikationsnummern/Wirtschafts-Identifikationsnummer/wirtschaftsidentifikationsnummer_node.html#js-toc-entry4)).
 > 
 > Source: [BZSt](https://www.bzst.de/DE/Unternehmen/Identifikationsnummern/Wirtschafts-Identifikationsnummer/wirtschaftsidentifikationsnummer_node.html#js-toc-entry4)
 
@@ -101,13 +101,13 @@ use Rechtlogisch\WirtschaftsId\WirtschaftsId;
 You can get a list of hints explaining why the provided input is not plausible. Hints do not change the validation result.  The `validate()` method returns a DTO with a `getHints()` method.
 
 > [!NOTE]
-> The keys of `getHints()` hold the stringified reference to the exception class. You can check for a particular error by comparing to the ::class constant. For example: `Rechtlogisch\WirtschaftsId\Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2026::class`.
+> The keys of `getHints()` hold the stringified reference to the exception class. You can check for a particular error by comparing to the ::class constant. For example: `Rechtlogisch\WirtschaftsId\Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2027::class`.
 
 ```php
 validateWirtschaftsId('DE123456788-00002')->getHints();
 // [
-//   'Rechtlogisch\WirtschaftsId\Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2026'
-//    => 'Unterscheidungsmerkmal (after -) is typically "00001" before year 2026.',
+//   'Rechtlogisch\WirtschaftsId\Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2027'
+//    => 'Unterscheidungsmerkmal (after -) is typically "00001" before year 2027.',
 // ]
 ```
 

--- a/src/Exceptions/UnterscheidungsmerkmalShouldBe00001BeforeYear2026.php
+++ b/src/Exceptions/UnterscheidungsmerkmalShouldBe00001BeforeYear2026.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Rechtlogisch\WirtschaftsId\Exceptions;
-
-class UnterscheidungsmerkmalShouldBe00001BeforeYear2026 extends WirtschaftsIdConstraintException {}

--- a/src/Exceptions/UnterscheidungsmerkmalShouldBe00001BeforeYear2027.php
+++ b/src/Exceptions/UnterscheidungsmerkmalShouldBe00001BeforeYear2027.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rechtlogisch\WirtschaftsId\Exceptions;
+
+class UnterscheidungsmerkmalShouldBe00001BeforeYear2027 extends WirtschaftsIdConstraintException {}

--- a/src/WirtschaftsId.php
+++ b/src/WirtschaftsId.php
@@ -134,8 +134,8 @@ class WirtschaftsId
             throw new Exceptions\UnterscheidungsmerkmalCantContainOnlyZeros('Unterscheidungsmerkmal (after '.self::SEPARATOR.') can\'t contain only zeros.');
         }
 
-        if ($afterSeparator !== '00001' && date('Y') < 2026) {
-            $this->result->addHint(Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2026::class, 'Unterscheidungsmerkmal (after '.self::SEPARATOR.') is typically "00001" before year 2026.');
+        if ($afterSeparator !== '00001' && date('Y') < 2027) {
+            $this->result->addHint(Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2027::class, 'Unterscheidungsmerkmal (after '.self::SEPARATOR.') is typically "00001" before year 2027.');
         }
     }
 

--- a/tests/TimeDependantTest.php
+++ b/tests/TimeDependantTest.php
@@ -2,15 +2,15 @@
 
 use Rechtlogisch\WirtschaftsId\WirtschaftsId;
 
-it('returns a hint for unterscheidungsmerkmal different than 00001 before year 2026', function (string $wirtschaftsId) {
+it('returns a hint for unterscheidungsmerkmal different than 00001 before year 2027', function (string $wirtschaftsId) {
     $result = (new WirtschaftsId($wirtschaftsId))->validate();
 
     expect($result->isValid())->toBeTrue()
         ->and($result->containsUnterscheidungsmerkmal())->toBeTrue()
         ->and($result->getErrors())->toBeEmpty()
         ->and($result->getHints())->not->toBeEmpty()
-        ->and($result->getHints())->toHaveKey(Rechtlogisch\WirtschaftsId\Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2026::class);
+        ->and($result->getHints())->toHaveKey(Rechtlogisch\WirtschaftsId\Exceptions\UnterscheidungsmerkmalShouldBe00001BeforeYear2027::class);
 })->with([
     'DE123456788-00002',
     'DE123456788-99999',
-])->skip(date('Y') >= 2026, 'This test is only relevant before year 2026.');
+])->skip(date('Y') >= 2027, 'This test is only relevant before year 2027.');


### PR DESCRIPTION
BZSt informed, that it will start issuing the Unterscheidungsmerkmal approx. in the 4th quarter of 2027 (cf. [bzst.de](https://www.bzst.de/DE/Unternehmen/Identifikationsnummern/Wirtschafts-Identifikationsnummer/wirtschaftsidentifikationsnummer_node.html#js-toc-entry4))